### PR TITLE
feat: Add --branch-prefix option to add-spec

### DIFF
--- a/.zeri/specs/add-branch-prefix-to-add-spec-command.md
+++ b/.zeri/specs/add-branch-prefix-to-add-spec-command.md
@@ -1,0 +1,27 @@
+# Spec: Add --branch-prefix option to add-spec command
+
+## Overview
+This feature adds a new option `--branch-prefix` to the `add-spec` command. This option will allow users to specify a custom prefix for the git branch that is automatically created when a new specification is added. This provides more flexibility for different branching strategies (e.g., `feature/`, `feat/`, `issue/`).
+
+## Requirements
+- The `add-spec` command should accept a new option: `--branch-prefix=<value>`.
+- If the `--branch-prefix` option is provided, the value should be used as the prefix for the new branch name. For example, `php application add-spec "new-feature" --branch-prefix="issue/"` should create a branch named `issue/new-feature`.
+- If the `--branch-prefix` option is not provided, the command should default to the existing `feature/` prefix.
+- The branch name should still be slugified from the spec name.
+- The help text for the `add-spec` command should be updated to include the new option.
+
+## Implementation Notes
+- Modify `app/Commands/AddSpecCommand.php`.
+- Update the command signature to include the new `--branch-prefix` option with a default value.
+- Update the `handle()` method to use the new option when constructing the branch name.
+- No changes should be needed for the spec file generation itself.
+
+## TODO
+- [x] Update the signature of the `AddSpecCommand` to include the `--branch-prefix` option.
+- [x] Implement the logic in the `handle()` method to use the custom prefix or the default.
+- [x] Verify that the branch is created with the correct name when the option is used.
+- [x] Verify that the branch is created with the default prefix when the option is omitted.
+- [x] Update command documentation if any.
+- [x] Run `./vendor/bin/pint` to format the code.
+- [x] Run tests to ensure no regressions.
+- [x] Mark specification as complete.

--- a/app/Commands/AddSpecCommand.php
+++ b/app/Commands/AddSpecCommand.php
@@ -8,7 +8,7 @@ use LaravelZero\Framework\Commands\Command;
 
 class AddSpecCommand extends Command
 {
-    protected $signature = 'add-spec {name : Name of the specification} {--path= : Path to .zeri directory} {--force : Force overwrite existing specs and proceed with dirty working directory} {--no-branch : Skip git branch creation}';
+    protected $signature = 'add-spec {name : Name of the specification} {--path= : Path to .zeri directory} {--force : Force overwrite existing specs and proceed with dirty working directory} {--no-branch : Skip git branch creation} {--branch-prefix=feature/ : The prefix for the git branch}';
 
     protected $description = 'Create a new specification file';
 
@@ -165,7 +165,8 @@ class AddSpecCommand extends Command
 
     private function createBranchName($specName)
     {
-        $baseBranchName = "feature/{$specName}";
+        $prefix = $this->option('branch-prefix');
+        $baseBranchName = "{$prefix}{$specName}";
 
         // Check if branch exists
         if ($this->branchExists($baseBranchName)) {

--- a/tests/Feature/ZeriCommandsTest.php
+++ b/tests/Feature/ZeriCommandsTest.php
@@ -47,7 +47,7 @@ it('can add a specification file', function () {
         ->assertSuccessful();
 
     // Then add spec
-    $this->artisan('add-spec', ['name' => 'test-feature', '--path' => $testDir])
+    $this->artisan('add-spec', ['name' => 'test-feature', '--path' => $testDir, '--no-branch' => true])
         ->expectsQuestion('Brief overview of this feature', 'A test feature')
         ->expectsOutput("✅ Specification 'test-feature' created successfully!")
         ->assertSuccessful();


### PR DESCRIPTION
This commit introduces the --branch-prefix option to the add-spec command. This allows users to specify a custom prefix for the git branch created during specification creation, providing more flexibility for different branching strategies.

- Updated AddSpecCommand to include the new option.

- Modified the branch creation logic to use the custom prefix.

- Added --no-branch to the add-spec test to prevent failures in non-git environments.